### PR TITLE
Changed getErrors() to errors()

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -117,6 +117,8 @@ abstract class Ardent extends Model
 
         $success = true;
 
+        $rules = ( empty( $rules ) ) ? static::$rules : $rules;
+
         if ( empty( $this->attributes ) && $this->autoHydrateEntityFromInput ) {
             // pluck only the fields which are defined in the validation rule-set
             $this->attributes = array_intersect_key( Input::all(), $rules );


### PR DESCRIPTION
I'm simply taking a hint from the validator class. This is way more like the rest of laravel.

From validator:

/**
     \* An alternative more semantic shortcut to the message container.
 *
- @return Illuminate\Support\MessageBag
  */
  public function errors()
  {
  return $this->messages;
  }

Signed-off-by: Andreas Heiberg git@andreas-heiberg.com
