### PR TITLE
autoHydrateEntityFromInput doesn't work properly

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -129,16 +129,16 @@ abstract class Ardent extends Model
 
         $success = false;
 
+        // check for overrides
+        $rules = ( empty( $rules ) ) ? static::$rules : $rules;
+        $customMessages = ( empty( $customMessages ) ) ? static::$customMessages : $customMessages;
+
         if ( empty( $this->attributes ) && $this->autoHydrateEntityFromInput ) {
             // pluck only the fields which are defined in the validation rule-set
             $this->attributes = array_intersect_key( Input::all(), $rules );
         }
 
         $data = $this->attributes; // the data under validation
-
-        // check for overrides
-        $rules = ( empty( $rules ) ) ? static::$rules : $rules;
-        $customMessages = ( empty( $customMessages ) ) ? static::$customMessages : $customMessages;
 
         if ( !empty( $data ) && !empty( $rules ) ) {
 


### PR DESCRIPTION
I think the rules MUST be define before the trigger of array_intersect_key() used by auto hydrate otherwhise the hydratation doesn't work for me. 
