### PR TITLE
Catches cases where an empty rule is listed

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -137,8 +137,14 @@ abstract class Ardent extends Model
      */
     public function validate( $rules = array(), $customMessages = array() ) {
 
-        // check for overrides
+        // check for overrides, then remove any empty rules
         $rules = ( empty( $rules ) ) ? static::$rules : $rules;
+        foreach ($rules as $field => $rls) {
+            if ($rls == '') {
+                unset($rules[$field]);
+            }
+        }
+
         $customMessages = ( empty( $customMessages ) ) ? static::$customMessages : $customMessages;
 
         if ( $this->forceEntityHydrationFromInput || ( empty( $this->attributes ) && $this->autoHydrateEntityFromInput ) ) {


### PR DESCRIPTION
If a model a rule that is empty, e.g., `'name' => ''` for whatever reason, the validation engine crashes.
This mod checks for any empty rules, and removes them from the array.
