### PR TITLE
Use the Eloquent setAttribute method when auto hydrated

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -139,7 +139,12 @@ abstract class Ardent extends Model
 
         if ( $this->forceEntityHydrationFromInput || ( empty( $this->attributes ) && $this->autoHydrateEntityFromInput ) ) {
             // pluck only the fields which are defined in the validation rule-set
-            $this->attributes = array_intersect_key( Input::all(), $rules );
+            $attributes = array_intersect_key( Input::all(), $rules );
+            
+            //Set each given attribute on the model
+            foreach ($attributes as $key => $value){
+            	$this->setAttribute($key, $value);
+            }
         }
 
         $data = $this->attributes; // the data under validation


### PR DESCRIPTION
To support mutator in the model, we must use the setAttribute method instead to set attributes when auto hydrated.
