### PR TITLE
Typehint for save() to follow Eloquent update

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -193,7 +193,7 @@ abstract class Ardent extends Model
      * @param callable $afterSave
      * @return bool
      */
-    public function save( $rules = array(), $customMessages = array(), Closure $beforeSave = null, Closure $afterSave = null ) {
+    public function save( array $rules = array(), $customMessages = array(), Closure $beforeSave = null, Closure $afterSave = null ) {
 
         // validate
         $validated = $this->validate( $rules, $customMessages );


### PR DESCRIPTION
The following update to Eloquent\Model has changed the blueprint for the save method to have a typehint:
https://github.com/laravel/framework/commit/f6fdecf9af2059f064174b82afdef95bbc21d0fa#src/Illuminate/Database/Eloquent/Model.php

This needs to be reflected in the Ardent overriding save method.
