### PR TITLE
Removed abstract from before class declaration

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Str;
  * Ardent - Self-validating Eloquent model base class
  *
  */
-abstract class Ardent extends Model
+class Ardent extends Model
 {
 
     /**


### PR DESCRIPTION
In cases where someone needs to extend multiple classes, they can use the following method to achieve this, but it won't work on abstract classes.

http://stackoverflow.com/questions/356128/can-i-extend-a-class-using-more-than-1-class-in-php/356431#356431

This is something fairly common when you're attempting to be extended by a base model, other packages will want to do the same, but the user is stuck on using a single package unless they use this method.

Since there is nothing abstract in the class that requires the whole class to be abstract, I've removed `abstract` from in front of the class declaration.
