### PR TITLE
Only hash password attributes that have changed

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -335,7 +335,9 @@ abstract class Ardent extends Model
         foreach ( $attributes as $key => $value ) {
 
             if ( in_array( $key, $passwordAttributes ) && !is_null( $value ) ) {
-                $result[$key] = Hash::make( $value );
+                if( $value != $this->getOriginal($key) ) {
+                    $result[$key] = Hash::make( $value );
+                }
             }
             else {
                 $result[$key] = $value;
@@ -343,6 +345,5 @@ abstract class Ardent extends Model
         }
 
         return $result;
-    }
-
+    }	
 }


### PR DESCRIPTION
I was having an issue that despite not submitting a new password, it was being re-hashed and I could no longer log in to my system.

To get around this, I've added in a simple check before you rehash password attributes to ensure that the value has actually changed.

Hopefully I've not missed something simple!
