### PR TITLE
Get attributes array with getter

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -139,7 +139,7 @@ abstract class Ardent extends Model
             }
         }
 
-        $data = $this->attributes; // the data under validation
+        $data = $this->getAttributes(); // the data under validation
 
         // perform validation
         $validator = Validator::make( $data, $rules, $customMessages );
@@ -302,11 +302,11 @@ abstract class Ardent extends Model
     protected function performSave( array $options ) {
 
         if ( $this->autoPurgeRedundantAttributes ) {
-            $this->attributes = $this->purgeArray( $this->attributes );
+            $this->attributes = $this->purgeArray( $this->getAttributes() );
         }
 
         if ( $this->autoHashPasswordAttributes ) {
-            $this->attributes = $this->hashPasswordAttributes( $this->attributes, static::$passwordAttributes );
+            $this->attributes = $this->hashPasswordAttributes( $this->getAttributes(), static::$passwordAttributes );
         }
 
         return parent::save( $options );


### PR DESCRIPTION
I wanted to be able to put in a manipulation layer when setting and getting attributes (for creating aliases for attributes, while keeping the database column names). When accessing the attributes array directly this was not possible since I needed to override `getAttributes()`.

This seems like the appropriate way of accessing the attributes array anyhow.
