### PR TITLE
Removed Update Method as it overwrites the Eloquent Update method

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -667,6 +667,30 @@ abstract class Ardent extends Model {
 
         return $rules;
     }
+    
+    /**
+     * Update a model already saved in the database.
+     *
+     * @param array   $rules
+     * @param array   $customMessages
+     * @param array   $options
+     * @param Closure $beforeSave
+     * @param Closure $afterSave
+     * @return bool
+     */
+    public function updateUniques(array $rules = array(),
+        array $customMessages = array(),
+        array $options = array(),
+        Closure $beforeSave = null,
+        Closure $afterSave = null
+    ) {
+        // Only automatically modify rules if there are none coming in
+        if (count($rules == 0)) {
+            $rules = $this->buildUniqueExclusionRules();
+        }
+
+        return $this->save($rules, $customMessages, $options, $beforeSave, $afterSave);
+    }
 
     /**
      * Find a model by its primary key.


### PR DESCRIPTION
Fix issue with Update not working on an eloquent model.

Calling $model->update($data) no longer works after this code was added.
$model->fill($data)->save() still works.

Conflicts with the Eloquent default update function:
http://laravel.com/api/source-class-Illuminate.Database.Eloquent.Model.html#946

Needs to fill the model with the data passed before calling $this->save().
