### PR TITLE
Restored PHP 5.3 functionality.  Issue #68.

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -701,7 +701,9 @@ abstract class Ardent extends Model {
      * @return Ardent|Collection
      */
     public static function find($id, $columns = array('*')) {
-        if (static::$throwOnFind && debug_backtrace()[1]['function'] != 'findOrFail') {
+        $debug = debug_backtrace();
+
+        if (static::$throwOnFind && $debug[1]['function'] != 'findOrFail') {
             return self::findOrFail($id, $columns);
         } else {
             return parent::find($id, $columns);


### PR DESCRIPTION
I hit this issue today working on a project and made the following quick fix to get it working in 5.3 again.  The other option we considered was to include the $debug declaration inside in the conditional.  This looks cleaner, in my opinion.
