### PR TITLE
Hook methods are not called properly anymore.

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -224,7 +224,9 @@ abstract class Ardent extends Model {
                 $method = $hook.ucfirst($rad).'e';
                 if (method_exists($myself, $method)) {
                     $eventMethod = $rad.$event;
-                    self::$eventMethod(array($myself, $method));
+                    self::$eventMethod(function($model) use ($method){
+                        return $model->$method();
+                    });
                 }
             }
         }


### PR DESCRIPTION
Whenever I add hooks like `beforeSave`, something like this appears:

`call_user_func_array() expects parameter 1 to be a valid callback, non-static method Employee::beforeSave() should not be called statically`
