### PR TITLE
Update illuminate dependencies version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.x",
-        "illuminate/database": "4.0.x",
-        "illuminate/validation": "4.0.x"
+        "illuminate/database": "4.x",
+        "illuminate/validation": "4.x"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Current ardent does not install with error message: 

```
Loading composer repositories with package information
Updating dependencies (including require-dev)                      
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: remove laravel/framework 4.1.x-dev
    - laravelbook/ardent dev-master requires illuminate/validation 4.0.x -> satisfiable by laravel/framework[4.0.x-dev, v4.0.0, v4.0.0-BETA2, v4.0.0-BETA3, v4.0.0-BETA4, v4.0.1, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7], illuminate/validation[4.0.x-dev, v4.0.0, v4.0.0-BETA2, v4.0.0-BETA3, v4.0.0-BETA4, v4.0.1, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7].
    - laravelbook/ardent dev-master requires illuminate/validation 4.0.x -> satisfiable by laravel/framework[4.0.x-dev, v4.0.0, v4.0.0-BETA2, v4.0.0-BETA3, v4.0.0-BETA4, v4.0.1, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7], illuminate/validation[4.0.x-dev, v4.0.0, v4.0.0-BETA2, v4.0.0-BETA3, v4.0.0-BETA4, v4.0.1, v4.0.2, v4.0.3, v4.0.4, v4.0.5, v4.0.6, v4.0.7].
    - Can only install one of: laravel/framework[4.1.x-dev, 4.0.x-dev].
    - Can only install one of: laravel/framework[v4.0.0, 4.1.x-dev].
    - Can only install one of: laravel/framework[v4.0.0-BETA2, 4.1.x-dev].
    - Can only install one of: laravel/framework[v4.0.0-BETA3, 4.1.x-dev].
    - Can only install one of: laravel/framework[v4.0.0-BETA4, 4.1.x-dev].
    - Can only install one of: laravel/framework[v4.0.1, 4.1.x-dev].
    - Can only install one of: laravel/framework[v4.0.2, 4.1.x-dev].
    - Can only install one of: laravel/framework[v4.0.3, 4.1.x-dev].
    - Can only install one of: laravel/framework[v4.0.4, 4.1.x-dev].
    - Can only install one of: laravel/framework[v4.0.5, 4.1.x-dev].
    - Can only install one of: laravel/framework[v4.0.6, 4.1.x-dev].
    - Can only install one of: laravel/framework[v4.0.7, 4.1.x-dev].
    - don't install illuminate/validation 4.0.x-dev|don't install laravel/framework 4.1.x-dev
    - don't install illuminate/validation v4.0.0|don't install laravel/framework 4.1.x-dev
    - don't install illuminate/validation v4.0.0-BETA2|don't install laravel/framework 4.1.x-dev
    - don't install illuminate/validation v4.0.0-BETA3|don't install laravel/framework 4.1.x-dev
    - don't install illuminate/validation v4.0.0-BETA4|don't install laravel/framework 4.1.x-dev
    - don't install illuminate/validation v4.0.1|don't install laravel/framework 4.1.x-dev
    - don't install illuminate/validation v4.0.2|don't install laravel/framework 4.1.x-dev
    - don't install illuminate/validation v4.0.3|don't install laravel/framework 4.1.x-dev
    - don't install illuminate/validation v4.0.4|don't install laravel/framework 4.1.x-dev
    - don't install illuminate/validation v4.0.5|don't install laravel/framework 4.1.x-dev
    - don't install illuminate/validation v4.0.6|don't install laravel/framework 4.1.x-dev
    - don't install illuminate/validation v4.0.7|don't install laravel/framework 4.1.x-dev
    - Installation request for laravel/framework 4.1.* -> satisfiable by laravel/framework[4.1.x-dev].
    - Installation request for laravelbook/ardent dev-master -> satisfiable by laravelbook/ardent[dev-master].

```
