### PR TITLE
Swapped headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,9 +358,8 @@ function __construct() {
   };
 }
 ```
-
-<a name="uniquerules"></a>
-## Updates with Unique Rules
+<a name="secure"></a>
+## Automatically Transform Secure-Text Attributes
 
 Suppose you have an attribute named `password` in your model class, but don't want to store the plain-text version in the database. The pragmatic thing to do would be to store the hash of the original content. Worry not, Ardent is fully capable of transmogrifying any number of secure fields automatically for you!
 
@@ -375,9 +374,9 @@ class User extends \LaravelBook\Ardent\Ardent {
 
 Ardent will automatically replace the plain-text password attribute with secure hash checksum and save it to database. It uses the Laravel `Hash::make()` method internally to generate hash.
 
+<a name="uniquerules"></a>
+## Updates with Unique Rules
 
-<a name="secure"></a>
-## Automatically Transform Secure-Text Attributes
 Ardent can assist you with unique updates. According to the Lavavel Documentation, when you update (and therefore validate) a field with a unique rule, you have to pass in the unique ID of the record you are updating. Without passing this ID, validation will fail because Laravel's Validator will think this record is a duplicate.
 
 From the Laravel Documentation:


### PR DESCRIPTION
The 'Automatically Transform Secure-Text Attributes' and 'Updates with Unique Rules' headings were the wrong way round.
