### PR TITLE
changed illuminate dependencies to 4.0.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.x",
-        "illuminate/database": "4.x",
-        "illuminate/validation": "4.x"
+        "illuminate/support": "4.0.x",
+        "illuminate/database": "4.0.x",
+        "illuminate/validation": "4.0.x"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Use 4.0.x until 4.1.x api is implemented. 
