### PR TITLE
Allow subclass overriding of Validator

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -511,7 +511,7 @@ abstract class Ardent extends Model {
 			$data = $this->getAttributes(); // the data under validation
 
 			// perform validation
-			$validator = self::makeValidator($data, $rules, $customMessages);
+			$validator = static::makeValidator($data, $rules, $customMessages);
 			$success   = $validator->passes();
 
 			if ($success) {


### PR DESCRIPTION
I want to be able to use Laravel's Validator's sometimes() feature with Ardent:

```
$v = Validator::make(...);
$v->sometimes('reason', 'required|max:500', function($input)
{
    return $input->games >= 100;
});
```

Allowing subclass overriding of Ardent::makeValidator() seems the easiest way.
