### PR TITLE
Update belongsTo and before/after callback calls to be compatible with Laravel 4.1

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -225,7 +225,7 @@ abstract class Ardent extends Model {
                 if (method_exists($myself, $method)) {
                     $eventMethod = $rad.$event;
                     self::$eventMethod(function($model) use ($method){
-                        return $model->$method();
+                        return $model->$method($model);
                     });
                 }
             }


### PR DESCRIPTION
This was a former pull request from Indatus:master now in its own branch Indatus:four-one-fixes
