### PR TITLE
Validation include mutated attributes

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -509,6 +509,8 @@ abstract class Ardent extends Model {
 			}
 
 			$data = $this->getAttributes(); // the data under validation
+			foreach($this->getMutatedAttributes() as $key) //Include mutated attributes
+      				$data[$key] = $this->mutateAttribute($key, null);
 
 			// perform validation
 			$validator = self::makeValidator($data, $rules, $customMessages);


### PR DESCRIPTION
Usually I do validations on mutated attributes. It would be nice to have it by default. What do you think?

Example: The database has two columns (`left` and `top`) to indicate coordinates. But I use a mutated attribute which returns 

```
function getCoordinates(){
  if($this->top && $this->left)
    return "{$this->top}, {$this->left}";
}
```

And I want to validate before saving that I have coordinates

```
static $rules = array(
  'coordinates' => 'required'
);
```

I know this can be solved by using more specific rules, but to be DRY I don't want to say twice that coordinates are composed by left and top (first said in the getCoordinates mutator accessor and later said in a rule validating the presence of both attributes, left and top).

It's just matter of semantics and clarity of code. In more complex situations, validating mutated attributes could result in cleaner, nicer code.
