### PR TITLE
Fix belongsTo() method to be compatible with Laravel 4.1.

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -356,7 +356,7 @@ abstract class Ardent extends Model {
 	 * @param  string  $otherKey
 	 * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
 	 */
-	public function belongsTo(($related, $foreignKey = NULL, $otherKey = NULL, $relation = NULL) {
+	public function belongsTo($related, $foreignKey = NULL, $otherKey = NULL, $relation = NULL) {
 		$backtrace = debug_backtrace(false);
 		$caller = ($backtrace[1]['function'] == 'handleRelationalArray')? $backtrace[3] : $backtrace[1];
 


### PR DESCRIPTION
This fixes the same issues that #123 pull request fixes but more extensively for models eager loaded `with()` relationships.
