### PR TITLE
validating and validated events observable fix

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -862,4 +862,15 @@ abstract class Ardent extends Model {
 
 		return $builder;
 	}
+	
+	public function getObservableEvents(){
+		return array_merge(
+			array(
+				'creating', 'created', 'updating', 'updated',
+				'deleting', 'deleted', 'saving', 'saved',
+				'restoring', 'restored', 'validating', 'validated'
+			),
+			$this->observables
+		);
+	}
 }


### PR DESCRIPTION
The validating event works when bound in the boot() function with the following code.

``` php
<?php
class Record extends Ardent{
    static public function boot(){
        parent::boot();
        self::validating(function($record){
            // this always works
        });
    }
}
```

The observable object binding of the validating event only works if the $observables property includes "validating" in its array and is subsequently returned in the array when calling getObservableEvents().

``` php
<?php
class Record extends Ardent{
    // only works if this is set
    public $observables = array('validating');
}
class Observer {
    public function validating($model){
        // works if $observables = array('validating');
    }
}

Record::observe(new Observer);
```

The getObservableEvents() needs to be extended in the Ardent class to work correctly.
