### PR TITLE
Request::hasSessionStore() has been removed

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -531,7 +531,7 @@ abstract class Ardent extends Model {
 				$this->validationErrors = $validator->messages();
 
 				// stash the input to the current session
-				if (!self::$externalValidator && Input::hasSessionStore()) {
+				if (!self::$externalValidator && Input::hasSession()) {
 					Input::flash();
 				}
 			}


### PR DESCRIPTION
Users of laravel 4.1 branch will get an error when the validator fires.

Due to the commit https://github.com/laravel/framework/commit/5a1829f7658a5cf752b97c354fa89386ee60d5dc made to 4.1 framework branch in which hasSessionStore() method has been removed.
