### PR TITLE
hasSessionStore has been removed

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -531,7 +531,7 @@ abstract class Ardent extends Model {
 				$this->validationErrors = $validator->messages();
 
 				// stash the input to the current session
-				if (!self::$externalValidator && Input::hasSessionStore()) {
+				if (!self::$externalValidator && Input::hasSession()) {
 					Input::flash();
 				}
 			}


### PR DESCRIPTION
hasSessionStore() method has been removed. In its place hasSession() method should be used. 

Reference: https://github.com/laravel/framework/commit/328e6cf72442aff228f1c60800ea4f1f9c1bf2cf
