### PR TITLE
Quick fix for breaking change in Laravel 4

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -531,7 +531,7 @@ abstract class Ardent extends Model {
 				$this->validationErrors = $validator->messages();
 
 				// stash the input to the current session
-				if (!self::$externalValidator && Input::hasSessionStore()) {
+				if (!self::$externalValidator && Input::hasSession()) {
 					Input::flash();
 				}
 			}


### PR DESCRIPTION
A recent laravel-4 update made the method Input::hasSessionStore() deprecated; breaking validation. The method to be used instead is Input::hasSession().

The current master throws this exception:

```
PHP Fatal error: Call to undefined method Illuminate\Http\Request::hasSessionStore() in vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php on line 205
```

This change fixes it. See issue #155 
