### PR TITLE
Make exclusion rules match Laravel optional where clause

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -608,8 +608,6 @@ abstract class Ardent extends Model {
         Closure $beforeSave = null,
         Closure $afterSave = null
     ) {
-        if ($this->exists) $rules = $this->buildUniqueExclusionRules($rules);
-
         return $this->internalSave($rules, $customMessages, $options, $beforeSave, $afterSave, false);
     }
 


### PR DESCRIPTION
Via http://laravel.com/docs/validation#rule-unique

If you currently provide an optional where clause it is removed and replaced by the primary key only. This keeps the additional where clause if it is specified.
