### PR TITLE
Hydrate relationships

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -520,14 +520,20 @@ abstract class Ardent extends Model {
 
 			if ($this->forceEntityHydrationFromInput || (empty($this->attributes) && $this->autoHydrateEntityFromInput)) {
 				$this->fill(Input::all());
-				// check if exists relationships and try to fill it
+				// check if exists and try to fill relationships
                 		$relations = $this->relationsToArray();
-                		if (!empty($relations)) {
+                			if (!empty($relations)) {
                     			foreach (array_keys($relations) as $relation) {
+                        			// check if some data was posted to this relation
                         			if (is_array(Input::get($relation))) {
-                        				if (count($this->$relation) == 1) {
-                            					$this->$relation->fill(Input::get($relation));
-                        				}
+		                            	// check if it as Eloquent Collection or not
+                            				if (get_class($this->$relation) != 'Illuminate\Database\Eloquent\Collection') {
+                                				// fill data into the model
+                                				$this->$relation->fill(Input::get($relation));
+                            				} else {
+                                				// sync the data if it is many-to-many ralationship
+                                				$this->$relation()->sync(Input::get($relation));
+                            				}
                         			}
                     			}
                 		}


### PR DESCRIPTION
Hydrate relationships when using form model binding.
When repopulating form input with array syntax, e.g. I have a <code>user</code> form with a related <code>profile</code>, I couldn't just save the related model, now I can just doing:
<code>
     $user->save();
     $user->profile->save();
</code>
Validate works as well.
It's helpfull when using syntax like in this fix: https://github.com/laravel/framework/pull/2036
