### PR TITLE
Use Input::except('_token')

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -519,7 +519,7 @@ abstract class Ardent extends Model {
 			$customMessages = (empty($customMessages))? static::$customMessages : $customMessages;
 
 			if ($this->forceEntityHydrationFromInput || (empty($this->attributes) && $this->autoHydrateEntityFromInput)) {
-				$this->fill(Input::all());
+				$this->fill(Input::except('_token'));
 			}
 
 			$data = $this->getAttributes(); // the data under validation


### PR DESCRIPTION
_token is not mass assignable, and when using Input::all(), It caused problem. So, its good practice to use Input::except('_token')
