### PR TITLE
Honor Eloquent global scopes

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -898,7 +898,7 @@ abstract class Ardent extends Model {
 			$builder->whereNull($this->getQualifiedDeletedAtColumn());
 		}
 
-		return $builder;
+		return $this->applyGlobalScopes($builder);
 	}
 
     /**


### PR DESCRIPTION
Found this bug today and noticed this one line commit fixes #220.

Thanks for maintaining Ardent!
