### PR TITLE
Use parent newQuery to get a Builder object.

### DIFF
--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -885,7 +885,7 @@ abstract class Ardent extends Model {
 	 * @return \Illuminate\Database\Eloquent\Builder
 	 */
 	public function newQuery($excludeDeleted = true) {
-		$builder = new Builder($this->newBaseQueryBuilder());
+		$builder = parent::newQuery();
 		$builder->throwOnFind = static::$throwOnFind;
 
 		// Once we have the query builders, we will set the model instances so the

--- a/src/LaravelBook/Ardent/Ardent.php
+++ b/src/LaravelBook/Ardent/Ardent.php
@@ -893,11 +893,6 @@ abstract class Ardent extends Model {
 		// while it is constructing and executing various queries against it.
 		$builder->setModel($this)->with($this->with);
 
-		if ($excludeDeleted and $this->softDelete)
-		{
-			$builder->whereNull($this->getQualifiedDeletedAtColumn());
-		}
-
 		return $builder;
 	}
 


### PR DESCRIPTION
This solves an issue where global scopes were not being applied.
I guess in theory it also solves other issues which are fixed upstreams in `Eloquent` but this is the one I know of for now.