### PR TITLE
Updated illuminate dependencies for ~5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "~4.1",
-        "illuminate/database": "~4.1",
-        "illuminate/validation": "~4.1"
+        "illuminate/support": "~5.0",
+        "illuminate/database": "~5.0",
+        "illuminate/validation": "~5.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Please merge this into main repo. This ensures compatibility for Laravel 5.

Currently L5 `composer update` fails.