### PR TITLE
Update illuminate constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
         "issues": "https://github.com/laravelbook/ardent/issues"
     },
     "require": {
-        "illuminate/support": "~5.1",
-        "illuminate/database": "~5.1",
-        "illuminate/validation": "~5.1",
-        "illuminate/events": "~5.1",
-        "illuminate/hashing": "~5.1"
+        "illuminate/support": "5.1.* || 5.2.*",
+        "illuminate/database": "5.1.* || 5.2.*",
+        "illuminate/validation": "5.1.* || 5.2.*",
+        "illuminate/events": "5.1.* || 5.2.*",
+        "illuminate/hashing": "5.1.* || 5.2.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since Laravel [doesn't follow semantic versioning](https://medium.com/@vinkla/laravel-packages-and-semantic-versioning-f62dc5accee5) we wont know if this package will break in version 5.3. The solution is to be more specific with the version constraint.