### PR TITLE
Match unique rules with no parameters

### DIFF
--- a/src/Ardent/Ardent.php
+++ b/src/Ardent/Ardent.php
@@ -838,7 +838,7 @@ abstract class Ardent extends Model {
             $ruleset = (is_string($ruleset))? explode('|', $ruleset) : $ruleset;
 
             foreach ($ruleset as &$rule) {
-                if (strpos($rule, 'unique:') === 0) {
+                if (strpos($rule, 'unique') === 0) {
                     // Stop splitting at 4 so final param will hold optional where clause
                     $params = explode(',', $rule, 4);
 


### PR DESCRIPTION
As it stands, the example provided in the README (`'email' => 'required|email|unique',`) doesn't work because `buildUniqueExclusionRules` is searching specifically for `unique:`, ending with a colon.

Presumably this isn't intentional, based on the later `count(explode(':', $params[0]))` check which currently would be impossible to trigger, so the string match has been adjusted.

That said, is there any concern of matching custom rules starting with 'unique'? The string check could be made more complicated to avoid this, but I personally think of it as a low priority concern.