### PR TITLE
Fix morphTo to correspond to Laravel 5.6

### DIFF
--- a/src/Ardent/Ardent.php
+++ b/src/Ardent/Ardent.php
@@ -448,7 +448,7 @@ abstract class Ardent extends Model {
 	 * @param  string  $id
 	 * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
 	 */
-	public function morphTo($name = null, $type = null, $id = null) {
+	public function morphTo($name = null, $type = null, $id = null, $ownerKey) {
 		// If no name is provided, we will use the backtrace to get the function name
 		// since that is most likely the name of the polymorphic interface. We can
 		// use that to get both the class and foreign key that will be utilized.

--- a/src/Ardent/Ardent.php
+++ b/src/Ardent/Ardent.php
@@ -448,7 +448,7 @@ abstract class Ardent extends Model {
 	 * @param  string  $id
 	 * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
 	 */
-	public function morphTo($name = null, $type = null, $id = null, $ownerKey) {
+	public function morphTo($name = null, $type = null, $id = null, $ownerKey = null) {
 		// If no name is provided, we will use the backtrace to get the function name
 		// since that is most likely the name of the polymorphic interface. We can
 		// use that to get both the class and foreign key that will be utilized.


### PR DESCRIPTION
Laravel 5.6 breaks the morphTo function as it no longer fits the definition in Laravel. This is necessary in order to continue to use this package with Laravel 5.6.

See [this](https://github.com/laravel/ideas/issues/587`).